### PR TITLE
Replace broken Hindawi link with Wiley

### DIFF
--- a/docs/Guidance/Requested_information_dcas.qmd
+++ b/docs/Guidance/Requested_information_dcas.qmd
@@ -11,7 +11,7 @@ categories: [DCAS, data availability, code availability, data, code, citations, 
 Data and Code Availability Statements (DCAS) can take on many forms. The examples below are taken from economics articles. For examples from other domains, see
 
 - [Springer](https://www.springernature.com/gp/authors/research-data-policy/data-availability-statements/12330880)
-- [Hindawi](https://www.hindawi.com/research.data/#statement.templates)
+- [Wiley](https://authors.wiley.com/author-resources/Journal-Authors/open-access/data-sharing-citation/data-sharing-policy.html)
 
 DCAS expand on and complement [data citations](../Guidance/Data_citation_guide.qmd).
 


### PR DESCRIPTION
## Summary

- Replaces the broken Hindawi link in the DCAS examples page with the Wiley data-sharing policy page

## Test plan

- [ ] Verify the Wiley link renders correctly and is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)